### PR TITLE
Fix undefined swift version

### DIFF
--- a/PodMergeExample/MergeFile
+++ b/PodMergeExample/MergeFile
@@ -1,3 +1,8 @@
+group 'SwiftUtilPods' do
+	swift_version! '4.2'
+	pod 'DeviceGuru', '4.0.0'
+end
+
 group 'Networking'
 	pod 'AFNetworking', '2.7.0'
 	pod 'SDWebImage', '~> 5.0'

--- a/PodMergeExample/Podfile
+++ b/PodMergeExample/Podfile
@@ -11,4 +11,5 @@ target 'PodMergeExample' do
   pod 'Networking', :path => 'MergedPods/Networking'
   pod 'UI', :path => 'MergedPods/UI'
   pod 'MergedSwiftPods', :path => 'MergedPods/MergedSwiftPods'
+  pod 'SwiftUtilPods', :path => 'MergedPods/SwiftUtilPods'
 end

--- a/PodMergeExample/Podfile.lock
+++ b/PodMergeExample/Podfile.lock
@@ -8,16 +8,18 @@ PODS:
     - Result (~> 4.1)
   - Networking (1.0.0)
   - Result (4.1.0)
+  - SwiftUtilPods (1.0.0)
   - UI (1.0.0)
 
 DEPENDENCIES:
   - MergedSwiftPods (from `MergedPods/MergedSwiftPods`)
   - Moya
   - Networking (from `MergedPods/Networking`)
+  - SwiftUtilPods (from `MergedPods/SwiftUtilPods`)
   - UI (from `MergedPods/UI`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - Alamofire
     - Moya
     - Result
@@ -27,6 +29,8 @@ EXTERNAL SOURCES:
     :path: MergedPods/MergedSwiftPods
   Networking:
     :path: MergedPods/Networking
+  SwiftUtilPods:
+    :path: MergedPods/SwiftUtilPods
   UI:
     :path: MergedPods/UI
 
@@ -36,8 +40,9 @@ SPEC CHECKSUMS:
   Moya: f4a4b80ff2f8a4ffc208dfb31cd91636622fee6e
   Networking: 844633d13d2328a829083b24ffaee99aea51c1de
   Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
+  SwiftUtilPods: 1415e0806030fbf5f2e8ef285b97ee1afb0ef1c9
   UI: 2aa82721ee430cd2f0ab314904bbe1a281fa2ff9
 
-PODFILE CHECKSUM: c99f0371dd5beae99026b9810a6f7d431cee616b
+PODFILE CHECKSUM: 358eef7190835a26ce287a30aaedfa21a388025c
 
 COCOAPODS: 1.8.1

--- a/lib/cocoapods-pod-merge/Main.rb
+++ b/lib/cocoapods-pod-merge/Main.rb
@@ -23,6 +23,12 @@ MergeFileSample = %(
   end
 )
 PodSpecWriter_Hook = %(
+  pre_install do |installer|
+    installer.analysis_result.specifications.each do |specs|
+      specs.swift_version = '4.2'
+    end
+  end
+
   post_install do |context|
     FileUtils.mkdir('Podspecs')
     context.aggregate_targets[0].specs.each do |spec|


### PR DESCRIPTION
Error that occurs

`- `DeviceGuru` does not specify a Swift version and none of the targets (`Dummy`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.`

Its happened because the [podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/a/4/f/DeviceGuru/4.0.0/DeviceGuru.podspec.json) file does not specify the swift version

Currently, in my trial to implement this in my project, I use swift 4.2 in the dummy project